### PR TITLE
:ambulance: Fixing reload issue github pages

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -22,7 +22,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forRoot(routes, { useHash: true })],
   exports: [RouterModule],
 })
 export class AppRoutingModule {}


### PR DESCRIPTION
Reloading of lazy loaded modules shows 404 page. This is fixed using hash location strategy